### PR TITLE
Rename Estimator to SamplerCallback, add OnlineTraceStatistics

### DIFF
--- a/src/devinterp/slt/callback.py
+++ b/src/devinterp/slt/callback.py
@@ -1,7 +1,7 @@
 import warnings
 
 
-class Estimator:
+class SamplerCallback:
     def __init__(self, device="cpu"):
         self.device = device
     

--- a/src/devinterp/slt/cov.py
+++ b/src/devinterp/slt/cov.py
@@ -5,11 +5,11 @@ import torch
 from scipy.sparse.linalg import eigsh
 from torch import nn
 
-from devinterp.slt.estimators import Estimator
+from devinterp.slt.callback import SamplerCallback
 
 WeightAccessor = Callable[[nn.Module], torch.Tensor]
 
-class CovarianceAccumulator(Estimator):
+class CovarianceAccumulator(SamplerCallback):
     """
     A callback to iteratively compute and store the covariance matrix of model weights.
     For use with `estimate`. 

--- a/src/devinterp/slt/llc.py
+++ b/src/devinterp/slt/llc.py
@@ -1,22 +1,19 @@
-import inspect
-import warnings
 from typing import Callable, Dict, List, Literal, Optional, Type, Union
 
 import numpy as np
-import pandas as pd
 import torch
 from torch.utils.data import DataLoader
 
 from devinterp.optim.sgld import SGLD
-from devinterp.slt.estimators import Estimator
+from devinterp.slt.callback import SamplerCallback
 from devinterp.slt.sampler import sample
 
 
-class LLCEstimator(Estimator):
+class LLCEstimator(SamplerCallback):
     def __init__(self, num_chains: int, num_draws: int, n: int, device="cpu"):
         self.num_chains = num_chains
         self.num_draws = num_draws
-        self.losses = np.zeros((num_chains, num_draws), dtype=np.float32)
+        self.losses = torch.zeros((num_chains, num_draws), dtype=torch.float32).to(device)
 
         self.n = torch.tensor(n, dtype=torch.float32).to(device)
         self.llc_per_chain = torch.zeros(num_chains, dtype=torch.float32).to(device)
@@ -34,34 +31,33 @@ class LLCEstimator(Estimator):
 
     def finalize(self):
         avg_losses = self.losses.mean(axis=1)
-        self.llc_per_chain = (self.n / self.n.log()).detach().cpu().numpy() * (avg_losses - self.init_loss)
+        self.llc_per_chain = (self.n / self.n.log()) * (avg_losses - self.init_loss)
         self.llc_mean = self.llc_per_chain.mean()
         self.llc_std = self.llc_per_chain.std()
         
     def sample(self):
         return {
-            "llc/mean": self.llc_mean.item(),
-            "llc/std": self.llc_std.item(),
-            **{f"llc-chain/{i}": self.llc_per_chain[i].item() for i in range(self.num_chains)},
-            "loss/trace": self.losses,
+            "llc/mean": self.llc_mean.cpu().numpy().item(),
+            "llc/std": self.llc_std.cpu().numpy().item(),
+            **{f"llc-chain/{i}": self.llc_per_chain[i].cpu().numpy().item() for i in range(self.num_chains)},
+            "loss/trace": self.losses.cpu().numpy(),
         }
     
     def __call__(self, chain: int, draw: int, loss: float):
         self.update(chain, draw, loss)
 
 
-class OnlineLLCEstimator(Estimator):
+class OnlineLLCEstimator(SamplerCallback):
     def __init__(self, num_chains: int, num_draws: int, n: int, device="cpu"):
         self.num_chains = num_chains
         self.num_draws = num_draws
 
-        self.losses = np.zeros((num_chains, num_draws), dtype=torch.float32)
-        self.llcs = np.zeros((num_chains, num_draws), dtype=torch.float32)
+        self.losses = torch.zeros((num_chains, num_draws), dtype=torch.float32).to(device)
+        self.llcs = torch.zeros((num_chains, num_draws), dtype=torch.float32).to(device)
 
         self.n = torch.tensor(n, dtype=torch.float32).to(device)
-        self.llc_per_chain = torch.zeros(num_chains, dtype=torch.float32).to(device)
-        self.llc_means = torch.tensor(num_chains, dtype=torch.float32).to(device)
-        self.llc_stds = torch.tensor(num_chains, dtype=torch.float32).to(device)
+        self.llc_means = torch.tensor(num_draws, dtype=torch.float32).to(device)
+        self.llc_stds = torch.tensor(num_draws, dtype=torch.float32).to(device)
 
         self.device = device
 
@@ -91,8 +87,8 @@ class OnlineLLCEstimator(Estimator):
         return {
             "llc/means": self.llc_means.cpu().numpy(),
             "llc/stds": self.llc_stds.cpu().numpy(),
-            "llc/trace": self.llcs,
-            "loss/trace": self.losses
+            "llc/trace": self.llcs.cpu().numpy(),
+            "loss/trace": self.losses.cpu().numpy()
         }
     
     def __call__(self, chain: int, draw: int, loss: float):

--- a/src/devinterp/slt/sampler.py
+++ b/src/devinterp/slt/sampler.py
@@ -1,6 +1,5 @@
 import inspect
 import itertools
-import warnings
 from copy import deepcopy
 from typing import Callable, Dict, List, Literal, Optional, Type, Union
 
@@ -68,7 +67,7 @@ def sample_single_chain(
 
             with torch.no_grad():
                 for callback in callbacks:
-                    call_with(callback, **locals())  # TODO: Cursed. Find a better way. 
+                    call_with(callback, **locals())  # TODO: Cursed. This is the way. 
 
 
     for callback in callbacks:

--- a/src/devinterp/slt/trace.py
+++ b/src/devinterp/slt/trace.py
@@ -1,0 +1,57 @@
+import numpy as np
+import torch
+
+from devinterp.slt.callback import SamplerCallback
+
+class OnlineTraceStatistics(SamplerCallback):
+    """Derivative callback that computes mean/std statistics of a specified trace online. Must
+    be called after the base callback has been called at each draw.
+    Parameters:
+        base_callback (ChainCallback): Base callback that computes original trace metric online.
+    """
+    def __init__(self, base_callback: SamplerCallback, attribute: str, device='cpu'):
+        self.base_callback = base_callback
+        self.attribute = attribute
+        self.validate_base_callback()
+
+        self.attribute = attribute
+
+        self.num_chains = base_callback.num_chains
+        self.num_draws = base_callback.num_draws
+
+        self.mean_by_chain = torch.zeros((self.num_chains, self.num_draws), dtype=torch.float32).to(device)
+        self.std_by_chain = torch.zeros((self.num_chains, self.num_draws), dtype=torch.float32).to(device)
+
+        self.mean_by_draw = torch.zeros(self.num_draws, dtype=torch.float32).to(device)
+        self.std_by_draw = torch.zeros(self.num_draws, dtype=torch.float32).to(device)
+
+    def validate_base_callback(self):
+        if not hasattr(self.base_callback, self.attribute):
+            raise ValueError(f"Base callback must have attribute {self.attribute}")
+        if not hasattr(self.base_callback, "num_chains"):
+            raise ValueError("Base callback must have attribute num_chains")
+        if not hasattr(self.base_callback, "num_draws"):
+            raise ValueError("Base callback must have attribute num_draws")
+
+    def sample(self):
+        return {
+            f'{self.attribute}/chain/mean': self.mean_by_chain.cpu().numpy(),
+            f'{self.attribute}/chain/std': self.std_by_chain.cpu().numpy(),
+            f'{self.attribute}/draw/mean': self.mean_by_draw.cpu().numpy(),
+            f'{self.attribute}/draw/std': self.std_by_draw.cpu().numpy(),
+        }
+    
+    def sample_at_draw(self, draw=-1):
+        return {
+            f'{self.attribute}/chain/mean': self.mean_by_chain[:, draw].cpu().numpy(),
+            f'{self.attribute}/chain/std': self.std_by_chain[:, draw].cpu().numpy(),
+            f'{self.attribute}/draw/mean': self.mean_by_draw[draw].cpu().numpy(),
+            f'{self.attribute}/draw/std': self.std_by_draw[draw].cpu().numpy(),
+        }
+
+    def __call__(self, draw: int):
+        attribute = getattr(self.base_callback, self.attribute)
+        self.mean_by_chain[:, draw] = attribute[:, :draw+1].mean(axis=1)
+        self.std_by_chain[:, draw] = attribute[:, :draw+1].std(axis=1)
+        self.mean_by_draw[draw] = attribute[:, draw].mean()
+        self.std_by_draw[draw] = attribute[:, draw].std()


### PR DESCRIPTION
- Renaming `Estimator` class to `ChainCallback`, since not all diagnostics will be directly involved with estimation
- Clean up some lines in `OnlineLLCEstimator` (no actual functionality should be changed), add a `self.finalized` flag
- Remove some unused imports
- Add a `OnlineTraceStatistics` callback to compute mean/std statistics for LLC and loss traces from an instance of `OnlineLLCEstimator`