### PR TITLE
Change init loss and n for llc estimation

### DIFF
--- a/src/devinterp/slt/llc.py
+++ b/src/devinterp/slt/llc.py
@@ -77,7 +77,7 @@ class OnlineLLCEstimator(SamplerCallback):
 
     @property
     def init_loss(self):
-        return self.losses[0, 0]
+        return self.losses[:, 0].mean()
 
     def finalize(self):
         self.llc_means = self.llcs.mean(axis=0)
@@ -114,9 +114,9 @@ def estimate_learning_coeff_with_summary(
 ) -> dict:
     
     if online:
-        llc_estimator = OnlineLLCEstimator(num_chains, num_draws, len(loader.dataset), device=device)
+        llc_estimator = OnlineLLCEstimator(num_chains, num_draws, optimizer_kwargs['num_samples'], device=device)
     else:
-        llc_estimator = LLCEstimator(num_chains, num_draws, len(loader.dataset), device=device)
+        llc_estimator = LLCEstimator(num_chains, num_draws, optimizer_kwargs['num_samples'], device=device)
 
     callbacks = [llc_estimator, *callbacks]
 


### PR DESCRIPTION
* Change init loss to be the average init loss of all chains rather than the init loss of only the first chain
* Change the `n` passed to the LLC estimators by `estimate_llc_coefficient_with_summary` to be the `num_samples` passed through `optimizer_kwargs` since the user chooses `n` here, but it isn't reflected by the LLC estimator. This shouldn't change the validity of any results or cause anything that previously diverged to converge or something, it should only affect the scalar that the LLC estimation gets multiplied by.