### PR TITLE
Don't ignore `device` argument in `estimate_rlcts` in `mnist.ipynb`

### DIFF
--- a/examples/mnist.ipynb
+++ b/examples/mnist.ipynb
@@ -616,7 +616,7 @@
                         "                num_draws=400,\n",
                         "                num_burnin_steps=0,\n",
                         "                num_steps_bw_draws=1,\n",
-                        "                device=DEVICE,\n",
+                        "                device=device,\n",
                         "                # verbose=False,\n",
                         "            )\n",
                         "            estimates[method].append(estimate)\n",


### PR DESCRIPTION
Very minor issue I noticed while looking through this notebook