### PR TITLE
Add a CI job for deploying to {test,}pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,179 @@
+name: Publish Python 🐍 distribution 📦 to PyPI or TestPyPI
+
+on:
+  release:
+    types: [published] # Only publish to pip when we formally publish a release
+  # For more on how to formally release on Github, read https://help.github.com/en/articles/creating-releases
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build-distribution:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Bump package version with local extension
+      run: etc/ci/bump-package-version.sh ".dev$(date +%s)"
+      if: ${{ ! ( startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' ) }}
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      PiPI: Publish Python 🐍 distribution 📦
+    if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' }} # only publish to PyPI on tag pushes
+    needs:
+    - build-distribution
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/devinterp
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-to-testpypi:
+    name: >-
+      TestPyPI: Publish Python 🐍 distribution 📦
+    if: ${{ ! ( startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' ) }} # only publish to TestPyPI on non-tag pushes
+    needs:
+    - build-distribution
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/devinterp
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+  # For ease of making this workflow required to merge PRs, and future-proofing the branch rules against changes to this workflow
+  check-publish:
+    runs-on: ubuntu-latest
+    needs:
+    - publish-to-testpypi
+    if: ${{ always() && ! ( startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' ) }}
+    steps:
+    - run: echo 'The triggering workflow (publish-to-testpypi) passed'
+      if: ${{ needs.publish-to-testpypi.result == 'success' }}
+    - run: echo 'The triggering workflow (publish-to-testpypi) failed' && false
+      if: ${{ needs.publish-to-testpypi.result != 'success' }}
+
+
+  github-release:
+    name: >-
+      Sign the Python 🐍 distribution 📦 with Sigstore
+      and upload them to GitHub Release
+    if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' }} # only publish to PyPI on tag pushes
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - run: find dist
+    - run: ls -la dist
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        '${{ github.ref_name }}' dist/**
+        --repo '${{ github.repository }}'
+
+  bump-package-version:
+    name: Bump package version
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' }} # only publish to PyPI on tag pushes
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Bump Package version
+      id: bumpPackageViaPush
+      run: |
+        etc/ci/bump-package-version.sh
+        remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        git config http.sslVerify false
+        git config user.name "Automated Publisher"
+        git config user.email "actions@users.noreply.github.com"
+        git remote add publisher "${remote_repo}"
+        git remote update
+        git show-ref # useful for debugging
+        git branch --verbose
+
+        git checkout -b temp
+        git branch -D main || true
+        git checkout -b main publisher/main
+        git add pyproject.toml
+        timestamp=$(date -u)
+        git commit -m "Automated Package Version Bump: ${timestamp} ${GITHUB_SHA}"
+        git push publisher main
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: always()
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v6
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        title: 'Package Version Bump'
+        body: >
+          This PR is auto-generated by
+          [create-pull-request](https://github.com/peter-evans/create-pull-request).
+        labels: automated pr
+      if: failure() && steps.bumpPackageViaPush.outcome == 'failure'

--- a/etc/ci/bump-package-version.sh
+++ b/etc/ci/bump-package-version.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+TOML_PATH="pyproject.toml"
+quote="'"
+dquote='"'
+
+VERSION_LINE="$(grep 'version\s*=\s*' "${TOML_PATH}")"
+FULL_VERSION_NUMBER="$(echo "${VERSION_LINE}" | sed 's/version\s*=\s*//g; s/"//g; s/\s//g')"
+VERSION_NUMBER="${FULL_VERSION_NUMBER%%+*}"
+if [ -z "$1" ]; then
+    # https://stackoverflow.com/a/4486087/377022
+    NEW_VERSION_NUMBER="$(awk -F. '/[0-9]+\./{$NF++;print}' OFS=. <<< "${VERSION_NUMBER}")"
+elif [[ "$1" == .* ]] || [[ "$1" == +* ]]; then
+    NEW_VERSION_NUMBER="${VERSION_NUMBER}$1"
+else
+    NEW_VERSION_NUMBER="${VERSION_NUMBER}+$1"
+fi
+NEW_VERSION_LINE="$(echo "${VERSION_LINE}" | sed "s/${FULL_VERSION_NUMBER}/${NEW_VERSION_NUMBER}/g")"
+echo "Updating ${TOML_PATH} from version ${FULL_VERSION_NUMBER} to ${NEW_VERSION_NUMBER}"
+sed "s/${VERSION_LINE}/${NEW_VERSION_LINE}/g" -i "${TOML_PATH}"
+
+# sanity check
+AGAIN_VERSION_LINE="$(grep 'version\s*=\s*' "${TOML_PATH}")"
+AGAIN_VERSION_NUMBER="$(echo "${AGAIN_VERSION_LINE}" | sed 's/version\s*=\s*//g; s/"//g; s/\s//g')"
+if [ "${NEW_VERSION_NUMBER}" != "${AGAIN_VERSION_NUMBER}" ]; then
+    echo "ERROR: Tried to change '${FULL_VERSION_NUMBER}' to '${NEW_VERSION_NUMBER}' in ${TOML_PATH},"
+    echo "  but somehow ended up with '${AGAIN_VERSION_NUMBER}'."
+    exit 1
+fi


### PR DESCRIPTION
This CI job will build the distribution and deploy to test-pypi on all pushes and PRs to main.
Additionally, it will deploy to pypi on all tagged releases.

The setup follows
https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/ very closely, with a few minor adjustments:
1. publishing to pypi happens only on releases
2. publishing to test-pypi does not happen on releases
3. the version is automatically bumpped to $ver.dev$(date +%s) on test-pypi deployment
4. a push or pull request is automatically created after a tagged release, bumping the version

Note that someone with permission will need to configure pypi and testpypi to accept packages from github actions as per [Python's instructions](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/).