### PR TITLE
Fixing two issues in MalaAcceptanceRate callback

### DIFF
--- a/src/devinterp/slt/mala.py
+++ b/src/devinterp/slt/mala.py
@@ -71,7 +71,7 @@ def mala_acceptance_probability(
 
 class MalaAcceptanceRate(SamplerCallback):
     """
-    Callback for computing the norm of the gradients of the optimizer / sampler.
+    Callback for computing MALA acceptance rate.
 
     Attributes:
         num_draws (int): Number of samples to draw. (should be identical to param passed to sample())

--- a/src/devinterp/slt/mala.py
+++ b/src/devinterp/slt/mala.py
@@ -130,7 +130,7 @@ class MalaAcceptanceRate(SamplerCallback):
         self.prev_mala_loss = mala_loss
         # params update only at the end, as decribed
         self.current_params = [
-            param.clone().detach() for param in list(model.parameters())
+            param.clone().detach() for param in model.parameters() if param.requires_grad
         ]
 
     def sample(self):


### PR DESCRIPTION
This fixes two issues:

1. The MALA acceptance rate was only being computed using the last parameter tensor in the model's parameter list. 
2. The MalaAcceptanceRate callback did not work correctly for models with some parameter gradients disabled using `requires_grad = False`. In most cases this resulted in a RuntimeError due to mismatched tensor shapes. 

It also fixed the docstring for MalaAcceptanceRate, which did not correctly describe the callback. 

These issues were addressed as follows:

1. Changed the `mala_acceptance_probability` function to accept either tensors or lists of tensors current and previous points and gradients, and updated the MalaAcceptanceRate `update` method accordingly. This function can still be used in the same way. 
2. Filtered out parameters with `requires_grad == False` when creating the `self.current_params` list in MalaAcceptanceRate. I also removed converting `model.parameters()` to a list inside of this list comprehension as this looked unnecessary?
