### PR TITLE
Fix GPU memory leak after each SGLD chain

### DIFF
--- a/src/devinterp/slt/sampler.py
+++ b/src/devinterp/slt/sampler.py
@@ -1,3 +1,4 @@
+import gc
 import inspect
 import itertools
 import warnings
@@ -127,6 +128,9 @@ def sample_single_chain(
                 with torch.no_grad():
                     for callback in callbacks:
                         call_with(callback, **locals())  # Cursed. This is the way.
+    del model
+    gc.collect()
+    torch.cuda.empty_cache()
 
 
 def _sample_single_chain(kwargs):


### PR DESCRIPTION
While trying to set up RLLCs for LLaMa, I ran into a memory leak that appeared to be happening about once per chain (it didn't depend on `num_draws`. I did not observe this for smaller models in the past, but it seems (according to Claude) that larger models can cause different behavior in CUDA's memory allocation and garbage collection for some reason. I don't know exactly why, but this change explicitly deletes, garbage collects, and clears CUDA cache for the variable causing the memory leak.

I put some checks for memory changes at different steps of `sample_single_chain` while testing. Step 1 is directly after the `ref_model` is deepcopied. See gist here for the exact locations: https://gist.github.com/georgeyw/899dd6354648da8b0af118a8260480ba

Below are the logs before and after the change in this PR. Note the differences in start of memory for each chain very closely or perfectly matches the memory change that happens directly after the copy of the model is made (`Memory change 1`). 

### Before change:
```
Start of chain memory 0: 4484854272
Memory change 1: 4869972480
Memory change 2: 8941076992
Chain 0:   0%|          | 0/3 [00:00<?, ?it/s]/usr/lib/python3.10/multiprocessing/popen_fork.py:66: RuntimeWarning: os.fork() was called. os.fork() is incompatible with multithreaded code, and JAX is multithreaded, so this will likely lead to a deadlock.
  self.pid = os.fork()
Chain 0: 100%|██████████| 3/3 [00:04<00:00,  1.39s/it]
Start of chain memory 0: 9363346432
Memory change 1: 10878976
Memory change 2: 4069400576
Chain 1: 100%|██████████| 3/3 [00:04<00:00,  1.36s/it]
Start of chain memory 0: 9374225408
Memory change 1: 4869906944
Memory change 2: 8891728384
Chain 2: 100%|██████████| 3/3 [00:04<00:00,  1.36s/it]
Start of chain memory 0: 14244132352
Memory change 1: 4830519808
Memory change 2: 8867414528
Chain 3:   0%|          | 0/3 [00:00<?, ?it/s]
---------------------------------------------------------------------------
OutOfMemoryError                          Traceback (most recent call last)
...
```
(rest of message is truncated)

### After change:
```
Start of chain memory 0: 9362232320
Memory change 1: 4882293248
Memory change 2: 8903066112
Chain 0: 100%|██████████| 3/3 [00:04<00:00,  1.36s/it]
Start of chain memory 0: 9375667200
Memory change 1: 4830716416
Memory change 2: 8900968960
Chain 1: 100%|██████████| 3/3 [00:04<00:00,  1.37s/it]
Start of chain memory 0: 9324090368
Memory change 1: 4881179136
Memory change 2: 8952873472
Chain 2: 100%|██████████| 3/3 [00:04<00:00,  1.37s/it]
Start of chain memory 0: 9374553088
Memory change 1: 4882489856
Memory change 2: 8933868032
Chain 3: 100%|██████████| 3/3 [00:04<00:00,  1.37s/it]
Start of chain memory 0: 9375863808
Memory change 1: 4861714944
Memory change 2: 8931770880
Chain 4: 100%|██████████| 3/3 [00:04<00:00,  1.37s/it]
1.6128429174423218
```