### PR TITLE
Fix print statement for final training and valuation metrics

### DIFF
--- a/examples/grokking.ipynb
+++ b/examples/grokking.ipynb
@@ -242,7 +242,7 @@
     "    train_acc, train_loss = test(model, train_dataset, params.device)\n",
     "    val_acc, val_loss = test(model, test_dataset, params.device)\n",
     "    if verbose:\n",
-    "        print(f\"Final Train Acc: {val_acc:.4f} | Final Train Loss: {val_loss:.4f}\")\n",
+    "        print(f\"Final Train Acc: {train_acc:.4f} | Final Train Loss: {train_loss:.4f}\")\n",
     "        print(f\"Final Val Acc: {val_acc:.4f} | Final Val Loss: {val_loss:.4f}\")\n",
     "    return all_models, df\n",
     "\n",


### PR DESCRIPTION
First statement printed valuation accuracy and loss instead of training accuracy and loss (in the example grokking notebook)