### PR TITLE
Set zarr version range in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "tqdm>=4.65.0",
     "transformers",
     "xarray>=2024.1.0",
-    "zarr>=3.0.0",
+    "zarr>=3.1.0,<3.2",
 ]
 classifiers = [
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
zarr 3.0.x: has RegularChunkGrid, but lacks zarr.core.dtype
zarr 3.1.x: has both RegularChunkGrid and zarr.core.dtype
zarr 3.2.x: has zarr.core.dtype, but no longer has RegularChunkGrid as a class

This is to fix some failures to import on the example notebook