### PR TITLE
include full WR in susceptibilities output

### DIFF
--- a/src/devinterp/slt/susceptibilities.py
+++ b/src/devinterp/slt/susceptibilities.py
@@ -173,8 +173,6 @@ def compute_susceptibilities(
     results: list[tuple[str, str, xr.DataArray, xr.DataArray]] = []
 
     for wr_name, wr in wr_map.items():
-        if wr_name == "full":
-            continue
         ds = wr.dataset
 
         # Verify expected layout since we slice positionally below.

--- a/tests/integration/test_custom_model.py
+++ b/tests/integration/test_custom_model.py
@@ -139,6 +139,8 @@ def test_susceptibilities(model_and_data):
         **_SAMPLER_KW,
     )
     assert "susceptibilities" in result.children
+    sus = result["susceptibilities"].dataset
+    assert list(sus.coords["wr"].values) == ["full", "head0"]
 
 
 @pytest.mark.parametrize("field", ["rmsprop_eps", "rmsprop_alpha"])

--- a/tests/integration/test_standalone.py
+++ b/tests/integration/test_standalone.py
@@ -108,7 +108,7 @@ def test_standalone_susceptibilities():
     sus = result["susceptibilities"].dataset
     assert "sus" in sus.data_vars
     assert "wr" in sus.coords
-    assert list(sus.coords["wr"].values) == ["l0h1"]
+    assert list(sus.coords["wr"].values) == ["full", "l0h1"]
 
 
 @pytest.mark.gpu


### PR DESCRIPTION
e.g.: in the example notebook, we have:

```python
susceptibilities(
    ...
    weight_restrictions={
        "full": None,
        "l0h0": l0h0_mask,
        "l0h1": create_param_masks(model, "l0h1"),
    },
    ...
```

but full one is currently not being calculated