### PR TITLE
examples: add a CPU-only LLC calibration against analytic learning coefficients

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ uv add devinterp
 
 See the [Quickstart Notebook](examples/quickstart.ipynb) ([open in Colab](https://colab.research.google.com/github/timaeus-research/devinterp/blob/main/examples/quickstart.ipynb)) or the [Quickstart Script](examples/quickstart.py) for examples of how to compute LLCs and susceptibilities on Qwen2.5-0.5B (GPU required).
 
+For a CPU-only check that needs no model download, [`examples/llc_calibration.py`](examples/llc_calibration.py) recovers the analytic learning coefficients of monomial (quasi-homogeneous) toy losses (`lambda = sum_i 1/p_i`) with `llc()`, a ground-truth calibration of the estimator.
+
 ## Quick Start
 
 ### Sampling with Observables

--- a/examples/llc_calibration.py
+++ b/examples/llc_calibration.py
@@ -1,0 +1,158 @@
+"""Calibrate devinterp's LLC estimator against analytic learning coefficients.
+
+Singular Learning Theory gives the local learning coefficient (LLC), i.e. the
+real log canonical threshold lambda, in closed form for monomial
+(quasi-homogeneous) losses. For
+
+    K(w) = 0.5 * sum_i w_i ** p_i        (each p_i a positive even integer),
+
+minimised at w = 0, the coefficient is
+
+    lambda = sum_i 1 / p_i
+
+so a regular d-parameter quadratic has lambda = d/2, and each quartic direction
+contributes 1/4 instead of 1/2 (a strictly more degenerate minimum).
+
+This example runs devinterp's high-level ``llc()`` on these toys and compares the
+estimate to the exact value: a ground-truth calibration of the estimator that
+complements ``quickstart.py`` (which runs it on Qwen2.5-0.5B). It is CPU-only and
+downloads nothing. The loss is a closed-form function of the weights, passed to
+``llc()`` through its ``loss_fn`` hook, so the only "data" is a dummy placeholder
+that fixes the batch shape.
+
+Run (about 15-20 s on a laptop CPU, no GPU):
+    python examples/llc_calibration.py
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import torch
+from datasets import Dataset
+
+from devinterp.slt.llc import llc
+from devinterp.utils import default_nbeta
+
+# SGLD settings, tuned once on the regular d=2 anchor (lambda = 1) and held fixed
+# across every case. localization = 0: these toys have a single minimum at w = 0,
+# so the chain can sample the tempered posterior of K itself with no pull back
+# toward the start. N is a virtual sample size: the loss is data-independent, so
+# there is no real dataset, and N only sets the SGLD inverse temperature n_beta.
+LR = 1e-3
+LOCALIZATION = 0.0
+N = 1000
+NUM_CHAINS = 8
+NUM_DRAWS = 1000
+NUM_BURNIN = 1000
+BATCH_SIZE = 16
+
+
+class MonomialLoss(torch.nn.Module):
+    """Loss surface K(w) = 0.5 * sum_i w_i ** p_i, minimised at w = 0."""
+
+    def __init__(self, powers: list[int]):
+        super().__init__()
+        self.powers = list(powers)
+        self.w = torch.nn.Parameter(torch.zeros(len(powers)))
+
+    def forward(self) -> torch.Tensor:
+        return 0.5 * sum(self.w[i] ** p for i, p in enumerate(self.powers))
+
+
+def monomial_loss_fn(model: MonomialLoss, input_ids: torch.Tensor) -> torch.Tensor:
+    """devinterp ``loss_fn`` hook: return K(w) broadcast to (batch, seq-1).
+
+    The loss is data-independent, so the dummy ``input_ids`` only fix the shape
+    that ``llc()`` averages over; that mean equals K(w).
+    """
+    k = model()
+    batch, seq_minus_one = input_ids.shape[0], input_ids.shape[1] - 1
+    return k.reshape(1, 1).expand(batch, seq_minus_one)
+
+
+def lambda_theory(powers: list[int]) -> float:
+    """Analytic learning coefficient lambda = sum_i 1 / p_i."""
+    return sum(1.0 / p for p in powers)
+
+
+def dummy_dataset(num_rows: int = 256, seq_len: int = 2) -> Dataset:
+    """Placeholder dataset: content is ignored, it only fixes the batch shapes."""
+    ds = Dataset.from_dict({"input_ids": [[0] * seq_len for _ in range(num_rows)]})
+    return ds.with_format("torch")  # devinterp's Observable expects tensor input_ids
+
+
+def estimate_llc(powers: list[int], *, seed: int = 0) -> tuple[float, float]:
+    """Estimate the LLC of K(w) = 0.5 * sum_i w_i ** p_i via devinterp's ``llc()``.
+
+    Returns (mean LLC across chains, standard deviation across chains).
+    """
+    torch.manual_seed(seed)
+    model = MonomialLoss(powers)  # initialised at the minimum w0 = 0
+    ds = dummy_dataset()
+    result = llc(
+        model=model,
+        dataset=ds,
+        observables={"train": ds},
+        loss_fn=monomial_loss_fn,
+        lr=LR,
+        n_beta=default_nbeta(N),
+        localization=LOCALIZATION,
+        num_chains=NUM_CHAINS,
+        num_draws=NUM_DRAWS,
+        num_burnin_steps=NUM_BURNIN,
+        batch_size=BATCH_SIZE,
+        num_init_loss_batches=4,
+        init_seed=seed,
+        device="cpu",
+    )
+    return float(result["llc_mean"]), float(result["llc_std"])
+
+
+CASES: list[tuple[str, list[int]]] = [
+    ("regular d=1", [2]),
+    ("regular d=2", [2, 2]),
+    ("regular d=3", [2, 2, 2]),
+    ("quartic 1D", [4]),
+    ("mixed", [4, 2]),
+]
+
+
+def main() -> None:
+    # Silence only devinterp's cosmetic "no output_path" notice (the calibration
+    # needs the summary stats, not the saved draws); leave other warnings visible.
+    warnings.filterwarnings("ignore", message=".*output_path.*")
+
+    # Compute every case first (progress bars stream here), then print one clean table.
+    results = []
+    for name, powers in CASES:
+        mean, std = estimate_llc(powers, seed=0)
+        theory = lambda_theory(powers)
+        results.append((name, powers, theory, mean, std, (mean - theory) / theory))
+
+    n_beta = default_nbeta(N)
+    print("\ndevinterp LLC estimator vs analytic learning coefficients")
+    print("K(w) = 0.5 * sum_i w_i^p_i   ->   lambda = sum_i 1/p_i")
+    print(
+        f"SGLD: {NUM_CHAINS} chains, {NUM_DRAWS} draws, {NUM_BURNIN} burn-in, "
+        f"lr {LR:g}, n_beta {n_beta:.1f} (CPU)\n"
+    )
+    header = f"{'case':<14}{'powers':<12}{'lambda':>8}{'LLC estimate':>20}{'rel err':>10}"
+    rule = "-" * len(header)
+    print(header)
+    print(rule)
+    for name, powers, theory, mean, std, rel in results:
+        est = f"{mean:.3f} +/- {std:.3f}"
+        print(f"{name:<14}{str(powers):<12}{theory:>8.3f}{est:>20}{rel:>+10.1%}")
+    print(rule)
+    print(
+        f"+/- is the standard deviation across the {NUM_CHAINS} chains. Every estimate\n"
+        "sits within about 6.5% of its analytic lambda and within roughly 1.5 standard\n"
+        "errors of it, so all five are statistically consistent with the exact value\n"
+        "(with a mild upward lean). The ordering is preserved: the quartic (lambda=1/4)\n"
+        "reads as more degenerate than a regular 1-D minimum (lambda=1/2)."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds `examples/llc_calibration.py`: a CPU-only, zero-download example that checks
devinterp's `llc()` against the **analytic** local learning coefficients of monomial
(quasi-homogeneous) losses, where the answer is known in closed form.

For `K(w) = 0.5 * sum_i w_i**p_i` (each `p_i` a positive even integer, minimised at
`w = 0`), the learning coefficient is `lambda = sum_i 1/p_i`. So a regular `d`-parameter
quadratic has `lambda = d/2`, and each quartic direction contributes `1/4` instead of
`1/2` (a strictly more degenerate minimum). The example runs `llc()` on these toys and
compares the estimate to the exact value.

## Why

`examples/` currently has only `quickstart.py`, which needs a GPU and downloads
Qwen2.5-0.5B. There is no lightweight example that shows the estimator is *correct* on a
case where the ground truth is exact. This adds that: it runs in ~20 s on a laptop CPU,
downloads nothing, and doubles as a calibration check on the estimator.

It also documents how to point `llc()` at a **non-LM loss**: it uses the public `loss_fn`
hook, with the loss a pure function of the weights and a dummy dataset that only fixes the
batch shape. That is a pattern users with custom losses currently have to reverse-engineer.

## Result (CPU, seed 0, deterministic across runs)

```
devinterp LLC estimator vs analytic learning coefficients
K(w) = 0.5 * sum_i w_i^p_i   ->   lambda = sum_i 1/p_i
SGLD: 8 chains, 1000 draws, 1000 burn-in, lr 0.001, n_beta 144.8 (CPU)

case          powers        lambda        LLC estimate   rel err
----------------------------------------------------------------
regular d=1   [2]            0.500     0.533 +/- 0.060     +6.5%
regular d=2   [2, 2]         1.000     1.018 +/- 0.077     +1.8%
regular d=3   [2, 2, 2]      1.500     1.535 +/- 0.115     +2.4%
quartic 1D    [4]            0.250     0.266 +/- 0.071     +6.4%
mixed         [4, 2]         0.750     0.763 +/- 0.071     +1.7%
----------------------------------------------------------------
```

Every estimate is within ~6.5% of its analytic `lambda` and within ~1.5 standard errors
(across the 8 chains), statistically consistent with the exact value, and the ordering is
preserved: the singular quartic (`lambda = 1/4`) reads as more degenerate than a regular
1-D minimum (`lambda = 1/2`).

## Notes

- CPU-only, no model download, ~20 s; byte-identical across runs (fixed seeds).
- Hyperparameters are tuned once on the `d=2` anchor (`lambda = 1`) and held fixed across
  every case; `localization = 0`, since these toys have a single global minimum.
- `ruff`-clean, no new dependencies, and the README "Example" section links it.
- Mirrors `quickstart.py`'s runnable-script style. Examples aren't covered by the test
  suite, so none is added; happy to add a fast `lambda_theory` unit test if you'd prefer.
